### PR TITLE
Fix off-by-one error in bounds for outer loop of sheet creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,15 @@ Input files should be a list of cards, one per line, prefixed by a number
 and a space. For example:
 
 ```
+1 Legion Loyalist
+1 Assassin's Trophy
+1 Questing Beast
+1 Murderous Rider
+1 Brazen Borrower
+1 Prismatic Vista
+1 Once Upon a Time
+1 Wrenn and Six
 1 Skullclamp
-2 Wrenn and Six
-1 Bonecrusher Giant
 ```
 
 Output

--- a/proxpy/ProxyMaker.py
+++ b/proxpy/ProxyMaker.py
@@ -73,7 +73,7 @@ class ProxyMaker():
 
         # Fit 9 images per sheet, generate the required
         # number of sheets to exhaust the input list.
-        for i in range(0, len(image_list)//9 + 1):
+        for i in range(0, (len(image_list)-1)//9 + 1):
             print("Generating sheet {}...".format(i+1))
             sheetname = "sheet{}.png".format(i+1)
             outfile = os.path.join(self.output_dir, sheetname)


### PR DESCRIPTION
If card list is a multiple of 9, don't generate an extra empty sheet.